### PR TITLE
feat: Better collectable cut

### DIFF
--- a/Source/LoggedString.cs
+++ b/Source/LoggedString.cs
@@ -17,7 +17,7 @@ public class LoggedString {
     }
 
     public bool isCleared() {
-        string[] clearedEvents = {"ROOM PASSED", "LEVEL COMPLETE", "CASSETTE", "BERRY", "CLOSE TO SPAWNPOINT"};
+        string[] clearedEvents = {"ROOM PASSED", "LEVEL COMPLETE", "CASSETTE", "BERRY", "CLOSE TO SPAWNPOINT", "HEART", "KEY", "SUMMIT_GEM"};
         return clearedEvents.Contains(Event);
     }
 

--- a/Source/VidcutterModule.cs
+++ b/Source/VidcutterModule.cs
@@ -46,6 +46,7 @@ public class VidcutterModule : EverestModule {
     private static object action;
     private static EverestModule vivHelperModule;
     private static Hook vivHelperRespawnHook;
+    private static Hook keyOnPlayerHook;
 
     public static Dictionary<string, TimeSpan> DurationCache = null;
 
@@ -151,6 +152,22 @@ public class VidcutterModule : EverestModule {
             Log("RESTART CHAPTER", session: session);
         }
         orig(self, mode, session, snow);
+    }
+
+    public static void OnCollectHeartGem(On.Celeste.HeartGem.orig_Collect orig, HeartGem self, Player player) {
+        Log("HEART", session: self.SceneAs<Level>().Session);
+        orig(self, player);
+    }
+
+    public static void OnCollectKey(Action<Key, Player> orig, Key self, Player player) {
+        if (self.Collidable)
+            Log("KEY", session: self.SceneAs<Level>().Session);
+        orig(self, player);
+    }
+
+    public static IEnumerator OnCollectSummitGem(On.Celeste.SummitGem.orig_SmashRoutine orig, SummitGem self, Player player, Level level) {
+        Log("SUMMIT_GEM", session: level.Session);
+        return orig(self, player, level);
     }
 
     public static void onPlayerUpdate(On.Celeste.Player.orig_Update orig, Player self) {
@@ -262,6 +279,13 @@ public class VidcutterModule : EverestModule {
         On.Celeste.Strawberry.OnCollect += OnCollectStrawberry;
         On.Celeste.Cassette.OnPlayer += OnCollectCassette;
         On.Celeste.LevelExit.ctor += OnRestart;
+        On.Celeste.HeartGem.Collect += OnCollectHeartGem;
+
+        MethodInfo keyOnPlayerMethod = typeof(Key).GetMethod("OnPlayer", BindingFlags.NonPublic | BindingFlags.Instance);
+        keyOnPlayerHook = new Hook(keyOnPlayerMethod, typeof(VidcutterModule).GetMethod(nameof(OnCollectKey), BindingFlags.Public | BindingFlags.Static));
+
+        On.Celeste.SummitGem.SmashRoutine += OnCollectSummitGem;
+
         typeof(VidcutterSpeedrunToolImport).ModInterop();
         SpeedrunToolInstalled = VidcutterSpeedrunToolImport.IgnoreSaveState is not null;
         if (SpeedrunToolInstalled) {
@@ -341,6 +365,10 @@ public class VidcutterModule : EverestModule {
         On.Celeste.Strawberry.OnCollect -= OnCollectStrawberry;
         On.Celeste.Cassette.OnPlayer -= OnCollectCassette;
         On.Celeste.LevelExit.ctor -= OnRestart;
+        On.Celeste.HeartGem.Collect -= OnCollectHeartGem;
+        keyOnPlayerHook?.Dispose();
+        keyOnPlayerHook = null;
+        On.Celeste.SummitGem.SmashRoutine -= OnCollectSummitGem;
         if (SpeedrunToolInstalled) {
             VidcutterSpeedrunToolImport.Unregister(action);
         }

--- a/Source/VidcutterModule.cs
+++ b/Source/VidcutterModule.cs
@@ -46,7 +46,6 @@ public class VidcutterModule : EverestModule {
     private static object action;
     private static EverestModule vivHelperModule;
     private static Hook vivHelperRespawnHook;
-    private static Hook keyOnPlayerHook;
 
     public static Dictionary<string, TimeSpan> DurationCache = null;
 
@@ -159,8 +158,8 @@ public class VidcutterModule : EverestModule {
         orig(self, player);
     }
 
-    public static void OnCollectKey(Action<Key, Player> orig, Key self, Player player) {
-        if (self.Collidable)
+    public static void OnCollectKey(On.Celeste.Key.orig_OnPlayer orig, Key self, Player player) {
+        if (self.GetType() == typeof(Key) && self.Collidable)
             Log("KEY", session: self.SceneAs<Level>().Session);
         orig(self, player);
     }
@@ -280,10 +279,7 @@ public class VidcutterModule : EverestModule {
         On.Celeste.Cassette.OnPlayer += OnCollectCassette;
         On.Celeste.LevelExit.ctor += OnRestart;
         On.Celeste.HeartGem.Collect += OnCollectHeartGem;
-
-        MethodInfo keyOnPlayerMethod = typeof(Key).GetMethod("OnPlayer", BindingFlags.NonPublic | BindingFlags.Instance);
-        keyOnPlayerHook = new Hook(keyOnPlayerMethod, typeof(VidcutterModule).GetMethod(nameof(OnCollectKey), BindingFlags.Public | BindingFlags.Static));
-
+        On.Celeste.Key.OnPlayer += OnCollectKey;
         On.Celeste.SummitGem.SmashRoutine += OnCollectSummitGem;
 
         typeof(VidcutterSpeedrunToolImport).ModInterop();
@@ -366,8 +362,7 @@ public class VidcutterModule : EverestModule {
         On.Celeste.Cassette.OnPlayer -= OnCollectCassette;
         On.Celeste.LevelExit.ctor -= OnRestart;
         On.Celeste.HeartGem.Collect -= OnCollectHeartGem;
-        keyOnPlayerHook?.Dispose();
-        keyOnPlayerHook = null;
+        On.Celeste.Key.OnPlayer -= OnCollectKey;
         On.Celeste.SummitGem.SmashRoutine -= OnCollectSummitGem;
         if (SpeedrunToolInstalled) {
             VidcutterSpeedrunToolImport.Unregister(action);

--- a/Source/VideoCreation.cs
+++ b/Source/VideoCreation.cs
@@ -13,6 +13,9 @@ public class VideoCreation {
     public int crf;
     public List<ProcessedVideo> videos = new List<ProcessedVideo>();
     public OuiVidcutterProgress progress;
+
+    private static readonly string[] CollectableEvents = { "BERRY", "CASSETTE", "HEART", "KEY", "SUMMIT_GEM" };
+
     public VideoCreation(OuiVidcutterProgress progress = null, int crf = 27) {
         this.progress = progress;
         this.crf = crf;
@@ -213,7 +216,12 @@ public class VideoCreation {
             
             if (nextline?.isCleared() != true) {
                 LoggedString clipEnd = currentLine;
-                
+
+                // Extend clip to death when ending on a collectable
+                if (CollectableEvents.Contains(currentLine.Event) && nextline?.Event == "DEATH") {
+                    clipEnd = nextline;
+                }
+
                 if (nextline?.Event == "INTER ROOM PASSED") {
                     currentClip.Add(currentLine);
                     clipEnd = currentClip.LastOrDefault(log => log.Room == nextline.Room && log.isCleared());


### PR DESCRIPTION
addresses #10 
so I decided add these feature on my own since they were bothering me during my runs

Basically this hooks `HeartGem`, `Key`, and `SummitGem` so they are actually tracked, and tweaks `ProcessLogs` so clips extend to the death event if you die right after grabbing a collectable

Tested it on my end and everything looks good, though I can't promise it's 100% bug-free
up to you if you want to pull this in :D